### PR TITLE
Add GetDistance function to HexMap

### DIFF
--- a/Includes/HexMap.h
+++ b/Includes/HexMap.h
@@ -21,6 +21,8 @@ class HexMap
     const HexTile* GetTile(int r, int q) const;
     std::vector<const HexTile*> GetAdjacencies(int r, int q) const;
 
+    int GetDistance(int r1, int q1, int r2, int q2) const;
+
  private:
     HexMap();
     ~HexMap();

--- a/Sources/HexMap.cpp
+++ b/Sources/HexMap.cpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <utility>
 #include <vector>
+#include <cmath>
 
 using namespace Civilizationpp;
 
@@ -75,4 +76,17 @@ std::vector<const HexTile*> HexMap::GetAdjacencies(int r, int q) const
     ret.erase(std::remove(ret.begin(), ret.end(), nullptr), ret.end());
 
     return ret;
+}
+
+int HexMap::GetDistance(int r1, int q1, int r2, int q2) const
+{
+    // Convert axial coordinates to cube coordinates
+    int y1 = -r1 - q1;
+    int y2 = -r2 - q2;
+
+    int dx = std::abs(q1 - q2);
+    int dy = std::abs(y1 - y2);
+    int dz = std::abs(r1 - r2);
+
+    return std::max({ dx, dy, dz });
 }

--- a/Tests/UnitTests/HexMapTests.cpp
+++ b/Tests/UnitTests/HexMapTests.cpp
@@ -123,3 +123,32 @@ TEST(HexMap, ShouldReturnVectorOfNonNullptrAdjacentTilesOnRequest)
               adjacenciesToEdge.end());
     ASSERT_EQ(adjacenciesToEdge.size(), (size_t)4);
 }
+
+TEST(HexMap, ShouldReturnDistanceOfTwoHexTile)
+{
+    // Two same tile should return 0 distance
+    ASSERT_EQ(0, HexMap::GetInstance()->GetDistance(0, 0, 0, 0));
+
+    // Adjacent tiles should return 1 distance
+    ASSERT_EQ(1, HexMap::GetInstance()->GetDistance(0, 0,  0, -1));
+    ASSERT_EQ(1, HexMap::GetInstance()->GetDistance(0, 0, -1,  0));
+    ASSERT_EQ(1, HexMap::GetInstance()->GetDistance(0, 0, -1,  1));
+    ASSERT_EQ(1, HexMap::GetInstance()->GetDistance(0, 0,  0,  1));
+    ASSERT_EQ(1, HexMap::GetInstance()->GetDistance(0, 0,  1,  0));
+    ASSERT_EQ(1, HexMap::GetInstance()->GetDistance(0, 0,  1, -1));
+
+    // Tiles in 2 distance
+    ASSERT_EQ(2, HexMap::GetInstance()->GetDistance(0, 0,  0, -2));
+    ASSERT_EQ(2, HexMap::GetInstance()->GetDistance(0, 0, -1, -1));
+    ASSERT_EQ(2, HexMap::GetInstance()->GetDistance(0, 0, -2,  0));
+    ASSERT_EQ(2, HexMap::GetInstance()->GetDistance(0, 0, -2,  1));
+    ASSERT_EQ(2, HexMap::GetInstance()->GetDistance(0, 0, -2,  2));
+    ASSERT_EQ(2, HexMap::GetInstance()->GetDistance(0, 0, -1,  2));
+    ASSERT_EQ(2, HexMap::GetInstance()->GetDistance(0, 0,  2, -1));
+    ASSERT_EQ(2, HexMap::GetInstance()->GetDistance(0, 0,  0,  2));
+    ASSERT_EQ(2, HexMap::GetInstance()->GetDistance(0, 0,  1,  1));
+    ASSERT_EQ(2, HexMap::GetInstance()->GetDistance(0, 0,  2,  0));
+    ASSERT_EQ(2, HexMap::GetInstance()->GetDistance(0, 0,  2, -1));
+    ASSERT_EQ(2, HexMap::GetInstance()->GetDistance(0, 0,  2, -2));
+    ASSERT_EQ(2, HexMap::GetInstance()->GetDistance(0, 0,  1, -2));
+}


### PR DESCRIPTION
`HexMap` 클래스에 `GetDistance` 함수를 추가했습니다. Axial 좌표계의 좌표로 두 타일의 좌표를 인자로 넘겨 받아, 두 타일 사이의 거리를 구해 정수형으로 반환합니다.